### PR TITLE
change repo-urls (mirrorlist.centos.org to vault.centos.org)

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -1,0 +1,27 @@
+[base]
+name=CentOS-7.9.2009 - Base
+baseurl=http://vault.centos.org/centos/7.9.2009/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-7.9.2009 - Updates
+baseurl=http://vault.centos.org/centos/7.9.2009/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-7.9.2009 - Extras
+baseurl=http://vault.centos.org/centos/7.9.2009/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-7.9.2009 - Plus
+baseurl=http://vault.centos.org/centos/7.9.2009/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 443/tcp 80/tcp
 ENV SHIBBOLETH_VERSION="3.4.1-1" \
     APACHE_VERSION="24u"
 
+COPY CentOS-Base.repo /etc/yum.repos.d/
+
+RUN yum clean all
+
 RUN yum -y update && yum -y install wget && wget --no-check-certificate https://shibboleth.net/cgi-bin/sp_repo.cgi?platform=CentOS_7 -O /etc/yum.repos.d/shibboleth.repo && yum -y install epel-release && yum -y install https://repo.ius.io/ius-release-el7.rpm && yum -y install httpd${APACHE_VERSION} httpd${APACHE_VERSION}-mod_ssl shibboleth-${SHIBBOLETH_VERSION} && yum -y clean all
 
 RUN echo "export LD_LIBRARY_PATH=/opt/shibboleth/lib64:$LD_LIBRARY_PATH" >> /etc/sysconfig/shibd && echo "export SHIBD_USER=shibd" >> /etc/sysconfig/shibd && sed -i -e "s|log4j.appender.shibd_log=.*$|log4j.appender.shibd_log=org.apache.log4j.ConsoleAppender|" -e "s|log4j.appender.warn_log=.*$|log4j.appender.warn_log=org.apache.log4j.ConsoleAppender|" -e "s|log4j.appender.tran_log=.*$|log4j.appender.tran_log=org.apache.log4j.ConsoleAppender|" -e "s|log4j.appender.sig_log=.*$|log4j.appender.sig_log=org.apache.log4j.ConsoleAppender|" /etc/shibboleth/shibd.logger


### PR DESCRIPTION
### Purpose

コンテナ内のCentOSのyumが参照しているリポジトリ
https://morrorlist.centos.org
の運用終了に伴い、後継のサービスにURLを変更する。

### Changes

/etc/yum.repos.d/CentOS-Base.repo 内で指定されているリポジトリURLを
morrorlist.centos.org のものから vault.centos.org の適切なパスに変更する。


